### PR TITLE
fix: removed min len for hparams of genmol v2

### DIFF
--- a/scripts/exps/frag/hparams_v2.yaml
+++ b/scripts/exps/frag/hparams_v2.yaml
@@ -4,24 +4,19 @@ linker_design_onestep:
   softmax_temp: 1.2
   randomness: 3
   gamma: 0
-  min_add_len: 30
 linker_design:
   softmax_temp: 1.2
   randomness: 3
   gamma: 0
-  min_add_len: 30
 motif_extension:
   softmax_temp: 1.2
   randomness: 1.0
   gamma: 0.3
-  min_add_len: 24
 scaffold_decoration:
   softmax_temp: 1.5
   randomness: 2
   gamma: 0.3
-  min_add_len: 24
 superstructure_generation:
   softmax_temp: 1.5
   randomness: 2
   gamma: 0.4
-  min_add_len: 24


### PR DESCRIPTION
This PR removes min_add_len from the GenMol V2 hparams file. Keeping it in the config causes errors such as:

TypeError: Sampler.fragment_linking() got an unexpected keyword argument 'min_add_len'

Tested: the code runs correctly after this change